### PR TITLE
fix: idの生成方法を修正

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -11,8 +11,13 @@
     { id: 1, name: 'new', count: 0 }
   ];
 
-  const addCounter = ():void => {
-    const newId: number = Math.max(...counters.map(c => c.id)) + 1;
+  const addCounter = (): void => {
+    let newId: number;
+    if (counters.length === 0) {
+      newId = 1;
+    } else {
+      newId = Math.max(...counters.map(c => c.id)) + 1;
+    }
     counters = [...counters, { id: newId, name: 'new', count: 0 }];
   };
 


### PR DESCRIPTION
issues #12 を修正しました。

修正前: counters 配列が空の場合に、`Math.max(...counters.map(c => c.id)) + 1 `という式を使用して新しいIDを生成しているため、配列が空のときに Math.max() が -Infinity を返してしまい、結果、newId が NaN（Not a Number）となり、意図した動作をしなくなるエラーになる可能性。

修正後: counters 配列が空かどうかをチェックし、空の場合は初期ID（例えば 1）を割り当てるようにするように修正。